### PR TITLE
added timekeeping

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ And through it all, the heart of a star pulses beneath the continent, its arcane
 ### [Lore](lore)
 
 - [Remi O](lore/remi-o.md)
+- [Timekeeping](lore/timekeeping.md)
 - [Waypoints](lore/waypoints.md)
 
 ### [Artifacts](artifacts)

--- a/astronomy/moons/bathys-pela.md
+++ b/astronomy/moons/bathys-pela.md
@@ -4,7 +4,7 @@
 
 ## Information
 
-- Orbital period: 1 week
+- Orbital period: 8 days (plus [lunar days](../../lore/timekeeping.md#lunar-days))
 
 ## Description
 

--- a/astronomy/moons/bathys-pela.md
+++ b/astronomy/moons/bathys-pela.md
@@ -4,7 +4,7 @@
 
 ## Information
 
-- Orbital period: 8 days (plus [lunar days](../../lore/timekeeping.md#lunar-days))
+- Orbital period: 8 days (plus [lunar days](../../lore/timekeeping.md#lunar-day))
 
 ## Description
 

--- a/astronomy/moons/dreg.md
+++ b/astronomy/moons/dreg.md
@@ -4,7 +4,7 @@
 
 ## Information
 
-- Orbital period: 42 days, or 1.5 Kivan months (plus [lunar days](../../lore/timekeeping.md#lunar-days))
+- Orbital period: 42 days, or 1.5 Kivan months (plus [lunar days](../../lore/timekeeping.md#lunar-day))
 
 ## History
 

--- a/astronomy/moons/dreg.md
+++ b/astronomy/moons/dreg.md
@@ -4,7 +4,7 @@
 
 ## Information
 
-- Orbital period: 1.5 months
+- Orbital period: 42 days, or 1.5 Kivan months (plus [lunar days](../../lore/timekeeping.md#lunar-days))
 
 ## History
 

--- a/astronomy/moons/kiva.md
+++ b/astronomy/moons/kiva.md
@@ -4,7 +4,7 @@
 
 ## Information
 
-- Orbital period: 1 month
+- Orbital period: 28 days (plus [lunar days](../../lore/timekeeping.md#lunar-days))
 
 ## Description
 

--- a/astronomy/moons/kiva.md
+++ b/astronomy/moons/kiva.md
@@ -4,7 +4,7 @@
 
 ## Information
 
-- Orbital period: 28 days (plus [lunar days](../../lore/timekeeping.md#lunar-days))
+- Orbital period: 28 days (plus [lunar days](../../lore/timekeeping.md#lunar-day))
 
 ## Description
 

--- a/lore/timekeeping.md
+++ b/lore/timekeeping.md
@@ -135,6 +135,8 @@ The Tides of Fathoms divide the year into twelve months based directly and exclu
 | 11     | Stratos|
 | 12     | Tropos |
 
+The Xiahuli ascribe the months to specific oceanic depths, seeing the movement of Kiva as a great float bobbing up and down through the seas of Mote. The months are named after these depths and broadly describe Kiva's mythological journey to the deepest point on the ocean floor in the month of Bathýs, then back up to the surface in the month of Pela. The binary Bathýs-Pela moon system acts as an emblem of these two extremes.
+
 #### Tidal Dates
 
 - 1 Pela: Vernal Equinox

--- a/lore/timekeeping.md
+++ b/lore/timekeeping.md
@@ -1,0 +1,97 @@
+# Timekeeping
+
+**Timekeeping** is handled in a few different ways by the various [societies of Esterfell](../societies/societies-of-esterfell.md). The measurement of days and months are generally based on physical aspects of [Mote](../mote/mote.md), such as the movement of its [natural satellites](../astronomy/moons/moons-of-mote.md) across the sky, which can allow for easy conversion between systems.
+
+## Units of Time
+
+### Second
+
+A second is an arbitrary small unit of time which divides larger timekeeping measurements.
+
+### Minute
+
+A minute is 60 seconds.
+
+### Hour
+
+An hour is 60 minutes, or 3,600 seconds.
+
+### Day
+
+A day is the time period of a full rotation of Mote with respect to its sun. On average, this is 24 hours (86,400 seconds), when not extended during a lunar day.
+
+#### Lunar Day
+
+Occasionally, when the orbits of the moons of Mote come in close proximity, the complicated interactions of their gravity and [starstuff](../artifacts/starstuff.md) energies can temporarily slow their movement across the sky. This confluence wreaks havoc on the surface of Mote, extending the length of the day as the world's rotation is temporarily disrupted and tidally locked by the amplified lunar forces. These periods are known as "lunar days".
+
+A lunar day slows the orbital speed of all involved moons for the entirety of their interaction as their gravitational and stellar forces drag against each other. This drag can vary in length from a few hours to over a day.
+
+### Month
+
+A month is the time period of a full orbit of a moon around Mote. This period varies depending on which moon is used as a reference point:
+
+- [Kivan](../astronomy/moons/kiva.md) month: 28 days
+- [Bathýs-Pelan](../astronomy/moons/bathys-pela.md) month: 8 days
+- [Dreg](../astronomy/moons/dreg.md): 42 days
+
+Note that these are average durations, as the length of a month will vary depending on whether a lunar day has occurred within the orbital period.
+
+The two common calendar systems in Esterfell use Kiva's orbit as the measure of a month, though both take different approaches to the eccentricity of this period.
+
+### Year
+
+A year is the time period of a full orbit of Mote around its sun, marking a full cycle of the seasons. This revolution takes approximately 336 days (or 29,030,400 seconds). Though the length of a Mote year is unaffected by lunar days, the perturbations of the sun and other celestial bodies can result in a slightly slower or faster revolution.
+
+## Calendar Systems
+
+The most commonly used calendar systems in [Esterfell](../mote/esterfell/esterfell.md) are the **Kivan Standard** and the **Tides of Fathoms**. Both calendars divide the year into twelve months marked roughly by the movement of Kiva, as Esterfell's largest moon has the most direct influence on tidal patterns and periods of starfall.
+
+### Kivan Standard
+
+- **Type:** lunisolar
+- **Introduction:** pre-Esterfell settlement
+- **Usage:** [Esterfell Accord](../societies/esterfell-accord/esterfell-accord.md), [Subros](../societies/subros.md), [Verdancy](../societies/verdancy/verdancy.md)
+
+A Kivan Standard year is divided into twelve months of twenty-eight days each. The length of a month is based on Kiva's uninterrupted orbital period, but this does not account for the presence of lunar days, which can cause the measure of months to drift over time as they fall out of alignment with Kiva's adjusted orbit. This allows for consistent month lengths for bookkeeping purposes, but makes it difficult to account for the disruption lunar days cause when determining the day of a week or the length of a year.
+
+| Number | Name   |
+|:-------|:-------|
+| 1      | Kaishi |
+| 2      | Bría   |
+| 3      | Lexon  |
+| 4      | Bail   |
+| 5      | Sephy  |
+| 6      | Mull   |
+| 7      | Lyax   |
+| 8      | Ëuil   |
+| 9      | Kret   |
+| 10     | Bhán   |
+| 11     | Merci  |
+| 12     | Dyrth  |
+
+The Kivan Standard was brought by settlers of Esterfell from prior nations that had previously developed this system, which made it convenient to continue its use among neighboring Esterfell nations. The names of the months are sourced from [pre-Esterfell deities](../pantheon/mote-pantheon.md), but enough time has passed since the people of Esterfell were separated from their ancestral lands that the worship of other gods has supplanted some of these domains.
+
+A week on the Kivan Standard calendar is a period of 7 days, which is exactly one-quarter of a month. As an arbitrary subdivision of a month, a week is not impacted by the eccentricity of lunar orbits.
+
+### Tides of Fathoms
+
+- **Type:** lunar
+- **Introduction:** pre-Esterfell settlement
+- **Usage:** [Xiahulia](../societies/xiahulia.md)
+
+The Tides of Fathoms divide the year into twelve months based directly on Kiva's orbit. The number of days in a month or in the year thus vary depending on whether a lunar day occurs during that period of time, as the Xiahuli include these days in a given month to keep their measures consistent with Kiva's varying orbital period and the resulting tidal forces.
+
+| Number | Name   |
+|:-------|:-------|
+| 1      | Pela   |
+| 2      | Aphotis|
+| 3      | Abyssi |
+| 4      | Demer  |
+| 5      | Benthis|
+| 6      | Hados  |
+| 7      | Bathýs |
+| 8      | Meso   |
+| 9      | Epiphis|
+| 10     | Photic |
+| 11     | Stratos|
+| 12     | Tropos |

--- a/lore/timekeeping.md
+++ b/lore/timekeeping.md
@@ -101,7 +101,7 @@ A Kivan Standard year is divided into twelve months of twenty-eight days each, m
 | 11     | Merci  |
 | 12     | Dyrth  |
 
-The Kivan Standard was brought by settlers of Esterfell from prior nations that had previously developed this system, which made it convenient to continue its use among neighboring Esterfell nations. The names of the months are sourced from [ancient Mote deities](../pantheon/mote-pantheon.md#ancient-mote-pantheon), but enough time has passed since the people of Esterfell were separated from their ancestral lands that the worship of other gods has supplanted some of these domains.
+The Kivan Standard was brought by settlers of Esterfell from prior nations that had previously developed this system, which made it convenient to continue its use among neighboring Esterfell nations. The names of the months are sourced from deities of the [ancient Mote pantheon](../pantheon/mote-pantheon.md#ancient-mote-pantheon), but enough time has passed since the people of Esterfell were separated from their ancestral lands that the worship of other gods has supplanted some of these domains.
 
 A week on the Kivan Standard calendar is a period of 7 days, which is exactly one-quarter of a month. As an arbitrary subdivision of a month, a week is not impacted by the eccentricity of lunar orbits.
 

--- a/lore/timekeeping.md
+++ b/lore/timekeeping.md
@@ -101,7 +101,7 @@ A Kivan Standard year is divided into twelve months of twenty-eight days each, m
 | 11     | Merci  |
 | 12     | Dyrth  |
 
-The Kivan Standard was brought by settlers of Esterfell from prior nations that had previously developed this system, which made it convenient to continue its use among neighboring Esterfell nations. The names of the months are sourced from [pre-Esterfell deities](../pantheon/mote-pantheon.md#pre-esterfell-pantheons), but enough time has passed since the people of Esterfell were separated from their ancestral lands that the worship of other gods has supplanted some of these domains.
+The Kivan Standard was brought by settlers of Esterfell from prior nations that had previously developed this system, which made it convenient to continue its use among neighboring Esterfell nations. The names of the months are sourced from [pre-Esterfell deities](../pantheon/mote-pantheon.md#ancient-mote-pantheon), but enough time has passed since the people of Esterfell were separated from their ancestral lands that the worship of other gods has supplanted some of these domains.
 
 A week on the Kivan Standard calendar is a period of 7 days, which is exactly one-quarter of a month. As an arbitrary subdivision of a month, a week is not impacted by the eccentricity of lunar orbits.
 

--- a/lore/timekeeping.md
+++ b/lore/timekeeping.md
@@ -101,7 +101,7 @@ A Kivan Standard year is divided into twelve months of twenty-eight days each, m
 | 11     | Merci  |
 | 12     | Dyrth  |
 
-The Kivan Standard was brought by settlers of Esterfell from prior nations that had previously developed this system, which made it convenient to continue its use among neighboring Esterfell nations. The names of the months are sourced from [pre-Esterfell deities](../pantheon/mote-pantheon.md), but enough time has passed since the people of Esterfell were separated from their ancestral lands that the worship of other gods has supplanted some of these domains.
+The Kivan Standard was brought by settlers of Esterfell from prior nations that had previously developed this system, which made it convenient to continue its use among neighboring Esterfell nations. The names of the months are sourced from [pre-Esterfell deities](../pantheon/mote-pantheon.md#pre-esterfell-pantheons), but enough time has passed since the people of Esterfell were separated from their ancestral lands that the worship of other gods has supplanted some of these domains.
 
 A week on the Kivan Standard calendar is a period of 7 days, which is exactly one-quarter of a month. As an arbitrary subdivision of a month, a week is not impacted by the eccentricity of lunar orbits.
 

--- a/lore/timekeeping.md
+++ b/lore/timekeeping.md
@@ -79,7 +79,7 @@ A week on the Kivan Standard calendar is a period of 7 days, which is exactly on
 - **Introduction:** pre-Esterfell settlement
 - **Usage:** [Xiahulia](../societies/xiahulia.md)
 
-The Tides of Fathoms divide the year into twelve months based directly on Kiva's orbit. The number of days in a month or in the year thus vary depending on whether a lunar day occurs during that period of time, as the Xiahuli include these days in a given month to keep their measures consistent with Kiva's varying orbital period and the resulting tidal forces.
+The Tides of Fathoms divide the year into twelve months based directly on Kiva's orbit. The number of days in a Kivan month or in the lunar year thus vary depending on whether a lunar day occurs during that period of time, as the Xiahuli include these days in a given month to keep their measures consistent with Kiva's varying orbital period and the resulting tidal forces.
 
 | Number | Name   |
 |:-------|:-------|

--- a/lore/timekeeping.md
+++ b/lore/timekeeping.md
@@ -44,23 +44,46 @@ A year is the time period of a full orbit of Mote around its sun, marking a full
 
 ## Calendar Systems
 
-The most commonly used calendar systems in [Esterfell](../mote/esterfell/esterfell.md) are the **Kivan Standard** and the **Tides of Fathoms**. Both calendars divide the year into twelve months marked roughly by the movement of Kiva, as Esterfell's largest moon has the most direct influence on tidal patterns and periods of starfall.
+The most commonly used calendar systems in [Esterfell](../mote/esterfell/esterfell.md) are the **Kivan Standard**, the **Darkharvest**, and the **Tides of Fathoms**. All three calendars divide the year into months marked roughly by the movement of a moon of Mote.
+
+### Darkharvest
+
+- **Type:** lunisolar (Dreg)
+- **Introduction:** pre-Esterfell Accord unification
+- **Usage:** agrarian groups within the [Esterfell Accord](../societies/esterfell-accord/esterfell-accord.md), [Subros](../societies/subros.md), and [Verdancy](../societies/verdancy/verdancy.md)
+
+The Darkharvest calendar is unique among the systems employed by Esterfell societies, as it uses Dreg's longer orbital period as a reference point to mark the months rather than Kiva. A Dreg month (often called a dreg for short) is 42 days long when not influenced by lunar days, meaning there are 8 dregs in a Darkharvest year.
+
+As the name suggests, this system tracks the dregs and seasons for the purpose of farming and harvesting crops. Seed and Douse mark the start of the spring season when the earliest planted crops begin to sprout and bloom, Harsh and Blight are the hot summer months, Thresh and Still are the autumn period when many crops are harvested, and Kiln and Fray bridge the coldest winter days.
+
+Although Darkharvest marks its months in dregs, the requirement to align with a season for agrarian accuracy means it must necessarily ignore random lunar days when measuring the year overall. The solution for this discrepancy varies by farmstead and by region, but when date precision is required for scheduling the planting of crops, the most typical approach is to add an extra day to a given dreg, and to force the advent of spring to the start of the year at 1 Seed, regardless of how much progress Dreg has made in its orbit.
+
+| Number | Name   |
+|:-------|:-------|
+| 1      | Seed   |
+| 2      | Douse  |
+| 3      | Harsh  |
+| 4      | Blight |
+| 5      | Thresh |
+| 6      | Still  |
+| 7      | Kiln   |
+| 8      | Fray   |
 
 ### Kivan Standard
 
-- **Type:** lunisolar
+- **Type:** solar
 - **Introduction:** pre-Esterfell settlement
 - **Usage:** [Esterfell Accord](../societies/esterfell-accord/esterfell-accord.md), [Subros](../societies/subros.md), [Verdancy](../societies/verdancy/verdancy.md)
 
-A Kivan Standard year is divided into twelve months of twenty-eight days each. The length of a month is based on Kiva's uninterrupted orbital period, but this does not account for the presence of lunar days, which can cause the measure of months to drift over time as they fall out of alignment with Kiva's adjusted orbit. This allows for consistent month lengths for bookkeeping purposes, but makes it difficult to account for the disruption lunar days cause when determining the day of a week or the length of a year.
+A Kivan Standard year is divided into twelve months of twenty-eight days each, making the year exactly 336 days long. The length of a month is based on Kiva's minimum uninterrupted orbital period, as Esterfell's largest moon has the most direct influence on tidal patterns and periods of starfall. However, the Kivan Standard's strict adherence to regular timekeeping does not account for the presence of lunar days, which can cause the measure of months to drift over time as they fall out of alignment with Kiva's adjusted orbit, making it difficult to account for the disruption lunar days can cause when determining the day of a week or the length of a month.
 
 | Number | Name   |
 |:-------|:-------|
 | 1      | Kaishi |
-| 2      | Bría   |
-| 3      | Lexon  |
-| 4      | Bail   |
-| 5      | Sephy  |
+| 2      | Griv   |
+| 3      | Bréa   |
+| 4      | Lexon  |
+| 5      | Bail   |
 | 6      | Mull   |
 | 7      | Lyax   |
 | 8      | Ëuil   |
@@ -75,11 +98,11 @@ A week on the Kivan Standard calendar is a period of 7 days, which is exactly on
 
 ### Tides of Fathoms
 
-- **Type:** lunar
+- **Type:** lunar (Kiva)
 - **Introduction:** pre-Esterfell settlement
 - **Usage:** [Xiahulia](../societies/xiahulia.md)
 
-The Tides of Fathoms divide the year into twelve months based directly on Kiva's orbit. The number of days in a Kivan month or in the lunar year thus vary depending on whether a lunar day occurs during that period of time, as the Xiahuli include these days in a given month to keep their measures consistent with Kiva's varying orbital period and the resulting tidal forces.
+The Tides of Fathoms divide the year into twelve months based directly and exclusively on Kiva's orbital period. The number of days in a Tidal month or Tidal year thus vary depending on whether a lunar day occurs during that period of time, as the Xiahuli include these days in a given month to keep their measures consistent with Kiva's varying orbital period and the resulting tidal forces.
 
 | Number | Name   |
 |:-------|:-------|

--- a/lore/timekeeping.md
+++ b/lore/timekeeping.md
@@ -48,44 +48,15 @@ The most commonly used calendar systems in [Esterfell](../mote/esterfell/esterfe
 
 A list of significant approximate dates are included for each calendar, including events with equivalents on all calendars, such as the advent of the seasons.
 
-### Darkharvest
-
-- **Type:** lunisolar (Dreg)
-- **Introduction:** pre-Esterfell Accord unification
-- **Usage:** agrarian groups within the [Esterfell Accord](../societies/esterfell-accord/esterfell-accord.md), [Subros](../societies/subros.md), and [Verdancy](../societies/verdancy/verdancy.md)
-
-The Darkharvest calendar is unique among the systems employed by Esterfell societies, as it uses Dreg's longer orbital period as a reference point to mark the months rather than Kiva. A Dreg month (often called a dreg for short) is 42 days long when not influenced by lunar days, meaning there are 8 dregs in a Darkharvest year.
-
-As the name suggests, this system tracks the dregs and seasons for the purpose of farming and harvesting crops. Seed and Douse mark the start of the spring season when the earliest planted crops begin to sprout and bloom, Harsh and Blight are the hot summer months, Thresh and Still are the autumn period when many crops are harvested, and Kiln and Fray bridge the coldest winter days.
-
-Although Darkharvest marks its months in dregs, the requirement to align with a season for agrarian accuracy means it must necessarily ignore random lunar days when measuring the year overall. The solution for this discrepancy varies by farmstead and by region, but when date precision is required for scheduling the planting of crops, the most typical approach is to add an extra day to a given dreg, and to force the advent of spring to the start of the year at 1 Seed, regardless of how much progress Dreg has made in its orbit.
-
-| Number | Name   |
-|:-------|:-------|
-| 1      | Seed   |
-| 2      | Douse  |
-| 3      | Harsh  |
-| 4      | Blight |
-| 5      | Thresh |
-| 6      | Still  |
-| 7      | Kiln   |
-| 8      | Fray   |
-
-#### Darkharvest Dates
-
-- 1 Seed: Vernal Equinox
-- 1 Harsh: Summer Solstice
-- 1 Thresh: Autumnal Equinox
-- 1 Kiln: Winter Solstice
-
 ### Kivan Standard
 
 - **Type:** solar
-- **Introduction:** pre-Esterfell settlement
+- **Introduction:** 1 KS
 - **Usage:** [Esterfell Accord](../societies/esterfell-accord/esterfell-accord.md), [Subros](../societies/subros.md), [Verdancy](../societies/verdancy/verdancy.md)
 
 A Kivan Standard year is divided into twelve months of twenty-eight days each, making the year exactly 336 days long. The length of a month is based on Kiva's minimum uninterrupted orbital period, as Esterfell's largest moon has the most direct influence on tidal patterns and periods of starfall. However, the Kivan Standard's strict adherence to regular timekeeping does not account for the presence of lunar days, which can cause the measure of months to drift over time as they fall out of alignment with Kiva's adjusted orbit, making it difficult to account for the disruption lunar days can cause when determining the day of a week or the length of a month.
 
+##### Kivan Standard Months
 | Number | Name   |
 |:-------|:-------|
 | 1      | Kaishi |
@@ -105,21 +76,31 @@ The Kivan Standard was brought by settlers of Esterfell from prior nations that 
 
 A week on the Kivan Standard calendar is a period of 7 days, which is exactly one-quarter of a month. As an arbitrary subdivision of a month, a week is not impacted by the eccentricity of lunar orbits.
 
+#### Kivan Standard Year Systems
+
+As the Esterfell settlers departed their ancient shores, they kept tracking the years with the Kivan Standard, dutifully counting the passage of time since year 1. Though the significance of this epoch has long been lost to the modern people of Esterfell, the numbering has remained intact; for example, Esterfell was settled by the first waves of immigrants starting in 3128.
+
+After the Esterfell Accord formed their union, the fledgling nation created a new system of tracking the years known as **Ambulare Populi** (abbreviated as "**AP**"). The name comes from an ancient Mote language and means "walk of the people". The Kaishi following the signing of the Accord on 23 Bhán 3181—known within the Accord as "Union Day"—thus became 1 AP under the Accord's new year system.
+
+The nation of Subros, having no particular allegiance to the Accord or deference to their holidays, continued to track their years from the ancient world. Esterfolk will also occasionally refer to the old year system, either when engaging in trade with Subrosians or when referring to pre-Accord historical events. When a distinction is needed, the abbreviation "**KS**" is sometimes used. Farmers tracking [Darkharvest](#darkharvest) seasonal cycles will use whichever numbering system aligns with their home nation, and their tendency to switch between the systems means Darkharvest almanacs are common references for quick conversions.
+
 #### Kivan Standard Dates
 
 - 14 Bréa: Vernal Equinox
 - 14 Mull: Summer Solstie
 - 14 Kret: Autumnal Equinox
+- 23 Bhán 3181: Union Day (Esterfell Accord)
 - 14 Dyrth: Winter Solstice
 
 ### Tides of Fathoms
 
 - **Type:** lunar (Kiva)
-- **Introduction:** pre-Esterfell settlement
+- **Introduction:** ancient Mote
 - **Usage:** [Xiahulia](../societies/xiahulia.md)
 
 The Tides of Fathoms divide the year into twelve months based directly and exclusively on Kiva's orbital period. The number of days in a Tidal month or Tidal year thus vary depending on whether a lunar day occurs during that period of time, as the Xiahuli include these days in a given month to keep their measures consistent with Kiva's varying orbital period and the resulting tidal forces.
 
+##### Tidal Months
 | Number | Name   |
 |:-------|:-------|
 | 1      | Pela   |
@@ -143,3 +124,35 @@ The Xiahuli ascribe the months to specific oceanic depths, seeing the movement o
 - 1 Demer: Autumnal Equinox
 - 1 Bathýs: Winter Solstice
 - 1 Photic: Vernal Equinox
+
+### Darkharvest
+
+- **Type:** lunisolar (Dreg)
+- **Introduction:** ancient Mote
+- **Usage:** agrarian groups within the [Esterfell Accord](../societies/esterfell-accord/esterfell-accord.md), [Subros](../societies/subros.md), and [Verdancy](../societies/verdancy/verdancy.md)
+
+The Darkharvest calendar is unique among the systems employed by Esterfell societies, as it uses Dreg's longer orbital period as a reference point to mark the months rather than Kiva. A Dreg month (often called a dreg for short) is 42 days long when not influenced by lunar days, meaning there are 8 dregs in a Darkharvest year.
+
+As the name suggests, this system tracks the dregs and seasons for the purpose of farming and harvesting crops. Seed and Douse mark the start of the spring season when the earliest planted crops begin to sprout and bloom, Harsh and Blight are the hot summer months, Thresh and Still are the autumn period when many crops are harvested, and Kiln and Fray bridge the coldest winter days.
+
+Although Darkharvest marks its months in dregs, the requirement to align with a season for agrarian accuracy means it must necessarily ignore random lunar days when measuring the year overall. The solution for this discrepancy varies by farmstead and by region, but when date precision is required for scheduling the planting of crops, the most typical approach is to add an extra day to a given dreg, and to force the advent of spring to the start of the year at 1 Seed, regardless of how much progress Dreg has made in its orbit.
+
+##### Darkharvest Dregs
+| Number | Name   |
+|:-------|:-------|
+| 1      | Seed   |
+| 2      | Douse  |
+| 3      | Harsh  |
+| 4      | Blight |
+| 5      | Thresh |
+| 6      | Still  |
+| 7      | Kiln   |
+| 8      | Fray   |
+
+#### Darkharvest Dates
+
+- 1 Seed: Vernal Equinox
+- 1 Harsh: Summer Solstice
+- 1 Thresh: Autumnal Equinox
+- 38 Thresh 3181: Union Day (Esterfell Accord)
+- 1 Kiln: Winter Solstice

--- a/lore/timekeeping.md
+++ b/lore/timekeeping.md
@@ -135,11 +135,11 @@ The Tides of Fathoms divide the year into twelve months based directly and exclu
 | 11     | Stratos|
 | 12     | Tropos |
 
-The Xiahuli ascribe the months to specific oceanic depths, seeing the movement of Kiva as a great float bobbing up and down through the seas of Mote. The months are named after these depths and broadly describe Kiva's mythological journey to the deepest point on the ocean floor in the month of Bathýs, then back up to the surface in the month of Pela. The binary Bathýs-Pela moon system acts as an emblem of these two extremes.
+The Xiahuli ascribe the months to specific oceanic depths, seeing the movement of Kiva as a great float bobbing up and down through the seas of Mote. The months are named after these depths and broadly describe Kiva's mythological journey to the deepest point on the ocean floor in the month of Bathýs at winter time, then back up to the surface in the summer month of Pela. The binary Bathýs-Pela moon system acts as an emblem of these two extremes.
 
 #### Tidal Dates
 
-- 1 Pela: Vernal Equinox
-- 1 Demer: Summer Solstie
-- 1 Bathýs: Autumnal Equinox
-- 1 Photic: Winter Solstice
+- 1 Pela: Summer Solstice
+- 1 Demer: Autumnal Equinox
+- 1 Bathýs: Winter Solstice
+- 1 Photic: Vernal Equinox

--- a/lore/timekeeping.md
+++ b/lore/timekeeping.md
@@ -101,7 +101,7 @@ A Kivan Standard year is divided into twelve months of twenty-eight days each, m
 | 11     | Merci  |
 | 12     | Dyrth  |
 
-The Kivan Standard was brought by settlers of Esterfell from prior nations that had previously developed this system, which made it convenient to continue its use among neighboring Esterfell nations. The names of the months are sourced from [pre-Esterfell deities](../pantheon/mote-pantheon.md#ancient-mote-pantheon), but enough time has passed since the people of Esterfell were separated from their ancestral lands that the worship of other gods has supplanted some of these domains.
+The Kivan Standard was brought by settlers of Esterfell from prior nations that had previously developed this system, which made it convenient to continue its use among neighboring Esterfell nations. The names of the months are sourced from [ancient Mote deities](../pantheon/mote-pantheon.md#ancient-mote-pantheon), but enough time has passed since the people of Esterfell were separated from their ancestral lands that the worship of other gods has supplanted some of these domains.
 
 A week on the Kivan Standard calendar is a period of 7 days, which is exactly one-quarter of a month. As an arbitrary subdivision of a month, a week is not impacted by the eccentricity of lunar orbits.
 

--- a/lore/timekeeping.md
+++ b/lore/timekeeping.md
@@ -46,6 +46,8 @@ A year is the time period of a full orbit of Mote around its sun, marking a full
 
 The most commonly used calendar systems in [Esterfell](../mote/esterfell/esterfell.md) are the **Kivan Standard**, the **Darkharvest**, and the **Tides of Fathoms**. All three calendars divide the year into months marked roughly by the movement of a moon of Mote.
 
+A list of significant approximate dates are included for each calendar, including events with equivalents on all calendars, such as the advent of the seasons.
+
 ### Darkharvest
 
 - **Type:** lunisolar (Dreg)
@@ -68,6 +70,13 @@ Although Darkharvest marks its months in dregs, the requirement to align with a 
 | 6      | Still  |
 | 7      | Kiln   |
 | 8      | Fray   |
+
+#### Darkharvest Dates
+
+- 1 Seed: Vernal Equinox
+- 1 Harsh: Summer Solstice
+- 1 Thresh: Autumnal Equinox
+- 1 Kiln: Winter Solstice
 
 ### Kivan Standard
 
@@ -96,6 +105,13 @@ The Kivan Standard was brought by settlers of Esterfell from prior nations that 
 
 A week on the Kivan Standard calendar is a period of 7 days, which is exactly one-quarter of a month. As an arbitrary subdivision of a month, a week is not impacted by the eccentricity of lunar orbits.
 
+#### Kivan Standard Dates
+
+- 14 Bréa: Vernal Equinox
+- 14 Mull: Summer Solstie
+- 14 Kret: Autumnal Equinox
+- 14 Dyrth: Winter Solstice
+
 ### Tides of Fathoms
 
 - **Type:** lunar (Kiva)
@@ -118,3 +134,10 @@ The Tides of Fathoms divide the year into twelve months based directly and exclu
 | 10     | Photic |
 | 11     | Stratos|
 | 12     | Tropos |
+
+#### Tidal Dates
+
+- 1 Pela: Vernal Equinox
+- 1 Demer: Summer Solstie
+- 1 Bathýs: Autumnal Equinox
+- 1 Photic: Winter Solstice

--- a/pantheon/mote-pantheon.md
+++ b/pantheon/mote-pantheon.md
@@ -2,7 +2,7 @@
 
 The **Mote pantheons** are multiple collections of beings of power from across the multiverse. [Mote](../mote/mote.md) does not possess a singular pantheon, and each domain is not resided over by only a single god. Instead, an innate magical field powered by the [starstuff](../artifacts/starstuff.md) that permeates all the worlds of [Fellspace](../astronomy/fellspace.md) acts as both divine amplifier and limiter, causing the collective belief of a deity's followers to be their only means of claiming and holding onto a domain.
 
-The term "god" is often used interchangeably on Mote with beings of "lesser" power, including archfey, celestial beings such as angels, and warlock patrons. The origin of such beings has little bearing on their capability to ascend to godhood, as long as they carry a sufficient volume of collective worship.
+The term "god" is often used interchangeably on Mote with beings of "lesser" power, including archfey, celestial beings such as angels, fiends, and kuo-toan protogods. The origin of such beings has little bearing on their capability to ascend to godhood, as long as they carry a sufficient volume of collective worship.
 
 ## Ancient Mote Pantheon
 

--- a/pantheon/mote-pantheon.md
+++ b/pantheon/mote-pantheon.md
@@ -4,7 +4,7 @@ The **Mote pantheons** are multiple collections of beings of power from across t
 
 The term "god" is often used interchangeably on Mote with beings of "lesser" power, including archfey, celestial beings such as angels, and warlock patrons. The origin of such beings has little bearing on their capability to ascend to godhood, as long as they carry a sufficient volume of collective worship.
 
-## Pre-Esterfell Pantheons
+## Ancient Mote Pantheon
 
 The people of [Esterfell](../mote/esterfell/esterfell.md) are descended from immigrants who traveled to the continent from distant now-forgotten lands. These groups had their own collections of deities, and though not all of them are now worshipped to the same degree as in antiquity, they survive in Esterfell cultures through the names of months in the [Kivan Standard calendar](../lore/timekeeping.md#kivan-standard) and some smaller relicious observations.
 
@@ -24,7 +24,7 @@ The people of [Esterfell](../mote/esterfell/esterfell.md) are descended from imm
 | Mullbree | deity | LN | Death |  |
 | Rikai  | deity | CN | Nature |  |
 
-## Esterfell Pantheons
+## Esterfell Pantheon
 
 As Esterfell formed a melting pot of new alliances separated from their historical societial boundaries, new gods also came into being, either as composites of old deities or from entities rising into power through collective worship.
 
@@ -38,7 +38,7 @@ The **Deities of Esterfell** table is a non-exhaustive list of beings with power
 | Pyr'xhalz | great old one | CE | [The Chosen](../organizations/the-chosen/the-chosen.md), Trickery, War, Mind |  |
 | [Ramil](ramil.md) | deva | LG | The Chosen, Light | crescent with radial triangles |
 
-## Borrowed Deities
+## Borrowed Pantheon
 
 On occasion, deities sourced from entirely different worlds became honorary Esterfell gods, though how they entered the public consciousness to a significant enough degree to find worshippers in a new world is not always well-understood.
 

--- a/pantheon/mote-pantheon.md
+++ b/pantheon/mote-pantheon.md
@@ -45,8 +45,8 @@ On occasion, deities sourced from entirely different worlds became honorary Este
 The **Deities of the Multiverse** table is a non-exhaustive list of beings of power sourced from other worlds. The table calls out their origins in the **Pantheon** column.
 
 ##### Deities of the Multiverse
-|  Deity | Classification | Alignment | Domains | Symbol | Pantheon |
-|:-------|:---------------|:---------:|:--------|:-------|:---------|
-| Deneir | deity | NG | Knowledge, Writing | lit candle above an open eye | The Forgotten Realms |
-| [Istus](istus.md) | deity | N | Knowledge, Fate, Destiny, Divination, Future Events | weaver's spindle with three strands | Greyhawk |
-| Silvanus | deity | N | Nature, Wilderness | oak leaf | The Forgotten Realms |
+|  Deity | Alignment | Domains | Symbol | Pantheon |
+|:-------|:---------:|:--------|:-------|:---------|
+| Deneir | NG | Knowledge, Writing | lit candle above an open eye | The Forgotten Realms |
+| [Istus](istus.md) | N | Knowledge, Fate, Destiny, Divination, Future Events | weaver's spindle with three strands | Greyhawk |
+| Silvanus | N | Nature, Wilderness | oak leaf | The Forgotten Realms |

--- a/pantheon/mote-pantheon.md
+++ b/pantheon/mote-pantheon.md
@@ -8,7 +8,7 @@ The term "god" is often used interchangeably on Mote with beings of "lesser" pow
 
 The people of [Esterfell](../mote/esterfell/esterfell.md) are descended from immigrants who traveled to the continent from distant now-forgotten lands. These groups had their own collections of deities, and though not all of them are now worshipped to the same degree as in antiquity, they survive in Esterfell cultures through the names of months in the [Kivan Standard calendar](../lore/timekeeping.md#kivan-standard) and some smaller relicious observations.
 
-##### Deities of Mote
+##### Ancient Deities of Mote
 |  Deity | Classification | Alignment | Domains | Symbol |
 |:-------|:---------------|:---------:|:--------|:-------|
 | Baylau | deity | CG | Trickery |  |
@@ -26,17 +26,27 @@ The people of [Esterfell](../mote/esterfell/esterfell.md) are descended from imm
 
 ## Esterfell Pantheons
 
-As Esterfell formed a melting pot of new alliances separated from their historical societial boundaries, new gods also came into being, either as composites of old deities or from entities rising into power through collective worship. On occasion, deities sourced from entirely different worlds became honorary Esterfell gods, though how they entered the public consciousness to a significant enough degree to find worshippers in a new world is not always well-understood.
+As Esterfell formed a melting pot of new alliances separated from their historical societial boundaries, new gods also came into being, either as composites of old deities or from entities rising into power through collective worship.
 
-The **Deities of Esterfell** table is a non-exhaustive list of beings with power and influence over Esterfell, representing some specific groups of entities that have been granted full or partial deification by various groups. The table calls out beings sourced from other worlds in the **Pantheon** column.
+The **Deities of Esterfell** table is a non-exhaustive list of beings with power and influence over Esterfell, representing some specific groups of entities that have been granted full or partial deification by various groups.
 
 ##### Deities of Esterfell
+|  Deity | Classification | Alignment | Domains | Symbol |
+|:-------|:---------------|:---------:|:--------|:-------|
+| [Lilith](lilith.md) | archfey/medusa | LG | [Attalya Grove](../mote/esterfell/lenya/attalya-grove.md), Nature, Serpents | a winged serpent |
+| [Phygius](phygius.md) | archfey | CN | [Middlestag Forest](../mote/esterfell/lenya/middlestag-forest.md), Nature, Feywild, Cervids | antlers with teardrops |
+| Pyr'xhalz | great old one | CE | [The Chosen](../organizations/the-chosen/the-chosen.md), Trickery, War, Mind |  |
+| [Ramil](ramil.md) | deva | LG | The Chosen, Light | crescent with radial triangles |
+
+## Borrowed Deities
+
+On occasion, deities sourced from entirely different worlds became honorary Esterfell gods, though how they entered the public consciousness to a significant enough degree to find worshippers in a new world is not always well-understood.
+
+The **Deities of the Multiverse** table is a non-exhaustive list of beings of power sourced from other worlds. The table calls out their origins in the **Pantheon** column.
+
+##### Deities of the Multiverse
 |  Deity | Classification | Alignment | Domains | Symbol | Pantheon |
 |:-------|:---------------|:---------:|:--------|:-------|:---------|
 | Deneir | deity | NG | Knowledge, Writing | lit candle above an open eye | The Forgotten Realms |
 | [Istus](istus.md) | deity | N | Knowledge, Fate, Destiny, Divination, Future Events | weaver's spindle with three strands | Greyhawk |
-| [Lilith](lilith.md) | archfey/medusa | LG | [Attalya Grove](../mote/esterfell/lenya/attalya-grove.md), Nature, Serpents | a winged serpent | Esterfell |
-| [Phygius](phygius.md) | archfey | CN | [Middlestag Forest](../mote/esterfell/lenya/middlestag-forest.md), Nature, Feywild, Cervids | antlers with teardrops | Esterfell |
-| Pyr'xhalz | great old one | CE | [The Chosen](../organizations/the-chosen/the-chosen.md), Trickery, War, Mind |  | Esterfell |
-| [Ramil](ramil.md) | deva | LG | The Chosen, Light | crescent with radial triangles | Esterfell |
 | Silvanus | deity | N | Nature, Wilderness | oak leaf | The Forgotten Realms |

--- a/pantheon/mote-pantheon.md
+++ b/pantheon/mote-pantheon.md
@@ -20,7 +20,7 @@ The people of [Esterfell](../mote/esterfell/esterfell.md) are descended from imm
 | Kretch | deity | N | Life |  |
 | Leixong | deity | NG | Light |  |
 | Lyaxen | deity | CE | Trickery |  |
-| Merci | deity | L | Knowledge |  |
+| Mercia | deity | L | Knowledge |  |
 | Mullbree | deity | LN | Death |  |
 | Rikai  | deity | CN | Nature |  |
 

--- a/pantheon/mote-pantheon.md
+++ b/pantheon/mote-pantheon.md
@@ -1,18 +1,42 @@
-# Mote Pantheon
+# Mote Pantheons
 
-The **Mote pantheon** is a series of deities sourced from multiple pantheons across the multiverse. Unlike many worlds, [Mote](../mote/mote.md) does not possess a singular pantheon, and each domain is not resided over by only a single god. Instead, an innate magical field powered by the [starstuff](../artifacts/starstuff.md) that permeates all the worlds of [Fellspace](../astronomy/fellspace.md) acts as both divine amplifier and limiter, causing the collective belief of a deity's followers to be their only means of claiming and holding onto a domain.
+The **Mote pantheons** are multiple collections of beings of power from across the multiverse. [Mote](../mote/mote.md) does not possess a singular pantheon, and each domain is not resided over by only a single god. Instead, an innate magical field powered by the [starstuff](../artifacts/starstuff.md) that permeates all the worlds of [Fellspace](../astronomy/fellspace.md) acts as both divine amplifier and limiter, causing the collective belief of a deity's followers to be their only means of claiming and holding onto a domain.
 
 The term "god" is often used interchangeably on Mote with beings of "lesser" power, including archfey, celestial beings such as angels, and warlock patrons. The origin of such beings has little bearing on their capability to ascend to godhood, as long as they carry a sufficient volume of collective worship.
 
-The following is not an exhaustive list of beings with power and influence over Mote, but represents some specific entities that have been granted full or partial deification by various groups.
+## Pre-Esterfell Pantheons
+
+The people of [Esterfell](../mote/esterfell/esterfell.md) are descended from immigrants who traveled to the continent from distant now-forgotten lands. These groups had their own collections of deities, and though not all of them are now worshipped to the same degree as in antiquity, they survive in Esterfell cultures through the names of months in the [Kivan Standard calendar](../lore/timekeeping.md#kivan-standard) and some smaller relicious observations.
 
 ##### Deities of Mote
+|  Deity | Classification | Alignment | Domains | Symbol |
+|:-------|:---------------|:---------:|:--------|:-------|
+| Baylau | deity | CG | Trickery |  |
+| Bhánta | deity | GE | Tempest |  |
+| Bréai | deity | LE | Knowledge |  |
+| Dyrth | deity | C | Nature |  |
+| Ëuilon | deity | NE | War |  |
+| Grivmac | deity | LG | Tempest |  |
+| Kretch | deity | N | Life |  |
+| Leixong | deity | NG | Light |  |
+| Lyaxen | deity | CE | Trickery |  |
+| Merci | deity | L | Knowledge |  |
+| Mullbree | deity | LN | Death |  |
+| Rikai  | deity | CN | Nature |  |
+
+## Esterfell Pantheons
+
+As Esterfell formed a melting pot of new alliances separated from their historical societial boundaries, new gods also came into being, either as composites of old deities or from entities rising into power through collective worship. On occasion, deities sourced from entirely different worlds became honorary Esterfell gods, though how they entered the public consciousness to a significant enough degree to find worshippers in a new world is not always well-understood.
+
+The **Deities of Esterfell** table is a non-exhaustive list of beings with power and influence over Esterfell, representing some specific groups of entities that have been granted full or partial deification by various groups. The table calls out beings sourced from other worlds in the **Pantheon** column.
+
+##### Deities of Esterfell
 |  Deity | Classification | Alignment | Domains | Symbol | Pantheon |
-|:-------|:-|:---------:|:--------|:-------|:-|
+|:-------|:---------------|:---------:|:--------|:-------|:---------|
 | Deneir | deity | NG | Knowledge, Writing | lit candle above an open eye | The Forgotten Realms |
 | [Istus](istus.md) | deity | N | Knowledge, Fate, Destiny, Divination, Future Events | weaver's spindle with three strands | Greyhawk |
-| [Lilith](lilith.md) | archfey/medusa | LG | [Attalya Grove](../mote/esterfell/lenya/attalya-grove.md), Nature, Serpents | a winged serpent | Mote |
-| [Phygius](phygius.md) | archfey | CN | [Middlestag Forest](../mote/esterfell/lenya/middlestag-forest.md), Nature, Feywild, Cervids | antlers with teardrops | Mote |
-| Pyr'xhalz | great old one | CE | [The Chosen](../organizations/the-chosen/the-chosen.md), Trickery, War, Mind |  | Mote |
-| [Ramil](ramil.md) | deva | LG | The Chosen, Light | crescent with radial triangles | Mote |
+| [Lilith](lilith.md) | archfey/medusa | LG | [Attalya Grove](../mote/esterfell/lenya/attalya-grove.md), Nature, Serpents | a winged serpent | Esterfell |
+| [Phygius](phygius.md) | archfey | CN | [Middlestag Forest](../mote/esterfell/lenya/middlestag-forest.md), Nature, Feywild, Cervids | antlers with teardrops | Esterfell |
+| Pyr'xhalz | great old one | CE | [The Chosen](../organizations/the-chosen/the-chosen.md), Trickery, War, Mind |  | Esterfell |
+| [Ramil](ramil.md) | deva | LG | The Chosen, Light | crescent with radial triangles | Esterfell |
 | Silvanus | deity | N | Nature, Wilderness | oak leaf | The Forgotten Realms |

--- a/pantheon/mote-pantheon.md
+++ b/pantheon/mote-pantheon.md
@@ -9,20 +9,20 @@ The term "god" is often used interchangeably on Mote with beings of "lesser" pow
 The people of [Esterfell](../mote/esterfell/esterfell.md) are descended from immigrants who traveled to the continent from distant now-forgotten lands. These groups had their own collections of deities, and though not all of them are now worshipped to the same degree as in antiquity, they survive in Esterfell cultures through the names of months in the [Kivan Standard calendar](../lore/timekeeping.md#kivan-standard) and some smaller relicious observations.
 
 ##### Ancient Deities of Mote
-|  Deity | Classification | Alignment | Domains | Symbol |
-|:-------|:---------------|:---------:|:--------|:-------|
-| Baylau | deity | CG | Trickery |  |
-| Bhánta | deity | GE | Tempest |  |
-| Bréai | deity | LE | Knowledge |  |
-| Dyrth | deity | C | Nature |  |
-| Ëuilon | deity | NE | War |  |
-| Grivmac | deity | LG | Tempest |  |
-| Kretch | deity | N | Life |  |
-| Leixong | deity | NG | Light |  |
-| Lyaxen | deity | CE | Trickery |  |
-| Mercia | deity | L | Knowledge |  |
-| Mullbree | deity | LN | Death |  |
-| Rikai  | deity | CN | Nature |  |
+|  Deity | Alignment | Domains | Symbol |
+|:-------|:---------:|:--------|:-------|
+| Baylau | CG | Trickery |  |
+| Bhánta | GE | Tempest |  |
+| Bréai | LE | Knowledge |  |
+| Dyrth | C | Nature |  |
+| Ëuilon | NE | War |  |
+| Grivmak | LG | Tempest |  |
+| Kretch | N | Life |  |
+| Leixong | NG | Light |  |
+| Lyaxen | CE | Trickery |  |
+| Mercia | L | Knowledge |  |
+| Mullbree | LN | Death |  |
+| Rikai  | CN | Nature |  |
 
 ## Esterfell Pantheon
 


### PR DESCRIPTION
- added Timekeeping page describing how different Esterfell societies track days, months, and years
- updated orbital periods of the moons and cross-referenced lunar days
- added pre-Esterfell pantheon as source of Kivan Standard month names