### PR TITLE
added Twill, updated Academerie info

### DIFF
--- a/docs/ch-2-people-of-mote/organizations/arcartisans/index.md
+++ b/docs/ch-2-people-of-mote/organizations/arcartisans/index.md
@@ -4,10 +4,11 @@
 
 ## Members
 
-- [Arnoldii Titanium](members/arnoldii-titanium.md)
-- [Charles Sexton](members/charles-sexton.md)
-- [Keltriss](members/keltriss.md)
-- [Kycri](members/kycri.md)
-- [Kyran](members/kyran.md)
-- [Pela Pipina](members/pela-pipina.md)
-- [S4R4](members/s4r4.md)
+- Arnaldii Titanium
+- Charles Sexton
+- Keltriss Swiftthistle
+- Kycri
+- Kyran
+- Pela Pipina
+- S4R4
+- [Twill](members/twill.md): Academerie representative

--- a/docs/ch-2-people-of-mote/organizations/arcartisans/members/twill.md
+++ b/docs/ch-2-people-of-mote/organizations/arcartisans/members/twill.md
@@ -1,0 +1,14 @@
+# Twill
+
+**Twill** works at [Balut's Academerie for the Magistically Inclinated](../../baluts-academerie/) as a gardener for the estate. She has recently taken on the task of spearheading a new initiative, investigating the potential of domestic magic alongside the [Guild of Associated Arcartisans](../).
+
+## Information
+
+### Mental
+
+- pronouns: she/her
+- languages: Common
+
+### Physical
+
+- species: human

--- a/docs/ch-2-people-of-mote/organizations/baluts-academerie/index.md
+++ b/docs/ch-2-people-of-mote/organizations/baluts-academerie/index.md
@@ -8,6 +8,7 @@
 
 - [Balut](members/balut.md): headmasterer
 - Z'mara: professor
+- [Twill](../arcartisans/members/twill.md): gardener
 
 ### Students
 
@@ -16,6 +17,6 @@
 - Jaydove Oakbough
 - Lindy Crestenshire
 - Scarlett Thatcher
-- [S4R4](../arcartisans/members/s4r4.md)
+- S4R4
 - Thaymseria
 - Xythia

--- a/docs/ch-2-people-of-mote/organizations/baluts-academerie/index.md
+++ b/docs/ch-2-people-of-mote/organizations/baluts-academerie/index.md
@@ -7,15 +7,15 @@
 ### Staff
 
 - [Balut](members/balut.md): headmasterer
-- [Zimira](members/zimira.md): professor
+- Z'mara: professor
 
 ### Students
 
-- [Faedove](members/faedove.md)
-- [Grambles](members/grambles.md)
-- [Jaydove Oakbough](members/jaydove-oakbough.md)
-- [Lindy Crestenshire](members/lindy-crestenshire.md)
-- [Scarlett Thatcher](members/scarlett-thatcher.md)
+- Faedove
+- Grambles
+- Jaydove Oakbough
+- Lindy Crestenshire
+- Scarlett Thatcher
 - [S4R4](../arcartisans/members/s4r4.md)
-- [Thaymseria](members/thaymseria.md)
-- [Xythia](members/xythia.md)
+- Thaymseria
+- Xythia

--- a/docs/ch-2-people-of-mote/organizations/baluts-academerie/members/balut.md
+++ b/docs/ch-2-people-of-mote/organizations/baluts-academerie/members/balut.md
@@ -7,7 +7,7 @@
 ### Mental
 
 - pronouns: he/him
-- languages: Primordial (Aquan), Common
+- languages: Primordial (Aquan), Common, Celestial, Elvish
 - title: headmasterer
 
 ### Physical
@@ -17,3 +17,11 @@
 ## History
 
 Balut immigrated to the [Esterfell Accord](../../../societies/esterfell-accord/) from [Xiahulia](../../../societies/xiahulia.md) and immediately sought to acquire all the magical knowledge he could from surface-dwelling societies. He quickly excelled in his studies, and soon decided that this bounty of magic needed to be shared with the world and become democratized. With this goal in mind, he founded a school carrying his own name and unique speech patterns.
+
+## Stat block
+
+Balut uses an _archmage_ stat block (Small Locathah) with the following changes:
+
+_**Resistances:**_ Charmed, Frightened, Paralyzed, Poison, Stunned (**Leviathan Will**)
+
+_**Amphibious.**_ Balut can breathe air and water.

--- a/docs/ch-2-people-of-mote/organizations/baluts-academerie/members/index.md
+++ b/docs/ch-2-people-of-mote/organizations/baluts-academerie/members/index.md
@@ -4,6 +4,7 @@
 
 - [Balut](balut.md): headmasterer
 - Z'mara: professor
+- [Twill](../../arcartisans/members/twill.md): gardener
 
 ## Students
 
@@ -12,6 +13,6 @@
 - Jaydove Oakbough
 - Lindy Crestenshire
 - Scarlett Thatcher
-- [S4R4](../../arcartisans/members/s4r4.md)
+- S4R4
 - Thaymseria
 - Xythia

--- a/docs/ch-2-people-of-mote/organizations/baluts-academerie/members/index.md
+++ b/docs/ch-2-people-of-mote/organizations/baluts-academerie/members/index.md
@@ -3,15 +3,15 @@
 ## Staff
 
 - [Balut](balut.md): headmasterer
-- [Zimira](zimira.md): professor
+- Z'mara: professor
 
 ## Students
 
-- [Faedove](faedove.md)
-- [Grambles](grambles.md)
-- [Jaydove Oakbough](jaydove-oakbough.md)
-- [Lindy Crestenshire](lindy-crestenshire.md)
-- [Scarlett Thatcher](scarlett-thatcher.md)
+- Faedove
+- Grambles
+- Jaydove Oakbough
+- Lindy Crestenshire
+- Scarlett Thatcher
 - [S4R4](../../arcartisans/members/s4r4.md)
-- [Thaymseria](thaymseria.md)
-- [Xythia](xythia.md)
+- Thaymseria
+- Xythia

--- a/docs/ch-2-people-of-mote/organizations/pipinas-pastries/index.md
+++ b/docs/ch-2-people-of-mote/organizations/pipinas-pastries/index.md
@@ -2,4 +2,7 @@
 
 **Pipina's Pastries** is a bakery in [Bridgeport](../../societies/esterfell-accord/bridgeport/).
 
-[- Members](members/)
+## Members
+
+- Pela Pipina: proprieter
+- Kyran: barista-in-training

--- a/docs/ch-2-people-of-mote/organizations/pipinas-pastries/members/index.md
+++ b/docs/ch-2-people-of-mote/organizations/pipinas-pastries/members/index.md
@@ -1,4 +1,4 @@
 # Pipina's Pastries Members
 
-- [Pela Pipina](../../arcartisans/members/pela-pipina.md): proprieter
-- [Kyran](../../arcartisans/members/kyran.md): barista-in-training
+- Pela Pipina: proprieter
+- Kyran: barista-in-training


### PR DESCRIPTION
- added Twill page (Academerie gardener and Arcartisans associate)
- updated Balut:
  - gave him the archmage stat block with locathah traits
  - added Celestial and Elvish to languages
- renamed Zimira to Z'mara
- corrected character name to Arnaldii Titanium
- removed nonexistent Academerie and Arcartisans member links